### PR TITLE
refactor: reduce board model class length

### DIFF
--- a/.rake_tasks~
+++ b/.rake_tasks~
@@ -1,0 +1,2 @@
+lint
+lint:auto_correct

--- a/lib/board_model.rb
+++ b/lib/board_model.rb
@@ -21,7 +21,7 @@ class Board < Observable
     # Indicates the type of the box (may be unknown for the player).
     @hidden_matrix = Array.new(@height) { Array.new(@width, '-') }
 
-    fill_board(test)
+    fill_board
   end
 
   def inside_board(row, col)
@@ -40,21 +40,14 @@ class Board < Observable
     # [*May take a long while because of randomness.]
     total_bombs = 0
     while total_bombs < @bombs
-      row = rand(@height)
-      column = rand(@width)
+      row = @test ? (@height - total_bombs - 1) : rand(@height)
+      column = @test ? (@width - total_bombs - 1) : rand(@width)
 
       next unless @hidden_matrix[row][column] != '*'
 
       @hidden_matrix[row][column] = '*'
       total_bombs += 1
     end
-  end
-
-  def fill_test_board_with_bombs
-    # [*May take a long while because of randomness.]
-    @hidden_matrix[@height - 1][@width - 1] = '*'
-    @hidden_matrix[@height - 2][@width - 1] = '*'
-    @hidden_matrix[@height - 1][@width - 2] = '*'
   end
 
   def fill_board_with_numbers
@@ -78,14 +71,10 @@ class Board < Observable
     bombs_surrounding
   end
 
-  def fill_board(test)
+  def fill_board
     # Fills the board with bombs and numbers indicating how many bombs
     # there are surrounding that square.
-    if test
-      fill_test_board_with_bombs
-    else
-      fill_board_with_bombs
-    end
+    fill_board_with_bombs
     fill_board_with_numbers
   end
 
@@ -142,9 +131,4 @@ class Board < Observable
   def bomb_explosion(row, col)
     @hidden_matrix[row][col] == '*'
   end
-
-  # Print hidden Matrix: function use for debuging
-  # def print_hidden
-  #   pp @hidden_matrix
-  # end
 end

--- a/test/board_model_test.rb
+++ b/test/board_model_test.rb
@@ -24,9 +24,9 @@ class BoardTest < Test::Unit::TestCase
 
   def test_mark_board_correctly
     expected = [%w[0 0 0 0 0],
-                %w[0 0 0 0 0],
-                %w[0 0 0 1 1],
-                ['0', '0', '1', '3', ' '],
+                %w[0 1 1 1 0],
+                ['0', '1', ' ', '2', '1'],
+                ['0', '1', '2', ' ', ' '],
                 ['0', '0', '1', ' ', ' ']]
     @board.mark(0, 0, notify_observer: false)
     assert_true(@board.equal(expected))
@@ -35,7 +35,7 @@ class BoardTest < Test::Unit::TestCase
   def test_notify_correctly
     view = BoardViewStub.new
     @board.add_observer(view)
-    @board.mark(0, 0, notify_observer: true)
+    @board.mark(0, 0)
     assert_true(view.board_was_printed)
   end
 
@@ -60,6 +60,8 @@ class BoardTest < Test::Unit::TestCase
   def test_win
     assert_false(@board.winner)
     @board.mark(0, 0)
+    @board.mark(3, 4)
+    @board.mark(4, 3)
     assert_true(@board.winner)
   end
 end


### PR DESCRIPTION
Board model class was to long => a refactor was made to it, to reduce the lines of the class